### PR TITLE
add architecture display

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -3,7 +3,7 @@
     "signed_by": "Signed By",
     "obtained_from": "Obtained From",
     "last_modified": "Last Modified",
-    "runtime_environment": "Runtime Environment",
+    "runtime_environment": "Architecture",
     "has64bit": "64-Bit",
     "mac_app_store": "Mac App Store",
     "identified_developer": "Identified Developer",

--- a/scripts/applications.py
+++ b/scripts/applications.py
@@ -15,6 +15,7 @@ def get_applications_info():
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (output, unused_error) = proc.communicate()
+
     try:
         plist = plistlib.readPlistFromString(output)
         # system_profiler xml is an array
@@ -50,6 +51,10 @@ def flatten_applications_info(array):
                 device['signed_by'] = obj[item][0]
             elif item == 'has64BitIntelCode' and obj[item] == 'yes':
                 device['has64bit'] = 1
+            elif item == 'arch_kind':
+                device['runtime_environment'] = obj[item]
+                if (obj[item] == 'arch_i64' or obj[item] == 'arch_i32_i64' or obj[item] == 'arch_arm_i64' or obj[item] == 'arch_ios'):
+                    device['has64bit'] = 1
         out.append(device)
     return out
 
@@ -65,6 +70,10 @@ def main():
         if sys.argv[1] == 'manualcheck':
             print 'Manual check: skipping'
             exit(0)
+            
+    # Set the encoding
+    reload(sys)  
+    sys.setdefaultencoding('utf8')
 
     # Get results
     result = dict()

--- a/views/applications_listing.php
+++ b/views/applications_listing.php
@@ -1,11 +1,5 @@
 <?php $this->view('partials/head'); ?>
 
-<?php //Initialize models needed for the table
-new Machine_model;
-new Reportdata_model;
-new Applications_model;
-?>
-
 <div class="container">
   <div class="row">
 	<div class="col-lg-12">
@@ -24,6 +18,7 @@ new Applications_model;
 			<th data-i18n="applications.obtained_from" data-colname='applications.obtained_from'></th>
 			<th data-i18n="applications.last_modified" data-colname='applications.last_modified'></th>
 			<th data-i18n="applications.has64bit" data-colname='applications.has64bit'></th>
+			<th data-i18n="applications.runtime_environment" data-colname='applications.runtime_environment'></th>
 			<th data-i18n="path" data-colname='applications.path'></th>
 			<th data-i18n="info" data-colname='applications.info'></th>
 		  </tr>
@@ -61,7 +56,7 @@ new Applications_model;
 
         $('.table th').map(function(){
 
-            columnDefs.push({name: $(this).data('colname'), targets: col});
+            columnDefs.push({name: $(this).data('colname'), targets: col, render: $.fn.dataTable.render.text()});
 
             if($(this).data('sort')){
               mySort.push([col, $(this).data('sort')])

--- a/views/applications_tab.php
+++ b/views/applications_tab.php
@@ -1,3 +1,6 @@
+<div id="applications-tab"></div>
+<h2 data-i18n="applications.applications"></h2>
+
 <p>
 <table class="applications table table-striped table-bordered">
 	<thead>
@@ -8,6 +11,7 @@
           <th data-i18n="applications.obtained_from"></th>
           <th data-i18n="applications.last_modified"></th>
           <th data-i18n="applications.has64bit"></th>
+          <th data-i18n="applications.runtime_environment"></th>
           <th data-i18n="path"></th>
           <th data-i18n="info"></th>
 		</tr>
@@ -23,6 +27,7 @@
           <td><?php echo str_replace(array('unknown','mac_app_store','apple','identified_developer'), array('Unknown','Mac App Store','Apple','Identified Developer'), $item->obtained_from); ?></td>
           <td><?php echo date("Y-m-d H:i:s", $item->last_modified); ?></td>
           <td><?php echo str_replace(array('1','0'), array('Yes','No'), $item->has64bit); ?></td>
+          <td><?php echo $item->runtime_environment; ?></td>
           <td><?php echo $item->path; ?></td>
           <td><?php echo $item->info; ?></td>
         </tr>

--- a/views/applications_tab.php
+++ b/views/applications_tab.php
@@ -27,7 +27,7 @@
           <td><?php echo str_replace(array('unknown','mac_app_store','apple','identified_developer'), array('Unknown','Mac App Store','Apple','Identified Developer'), $item->obtained_from); ?></td>
           <td><?php echo date("Y-m-d H:i:s", $item->last_modified); ?></td>
           <td><?php echo str_replace(array('1','0'), array('Yes','No'), $item->has64bit); ?></td>
-          <td><?php echo $item->runtime_environment; ?></td>
+          <td><?php echo str_replace(array('arch_i64','arch_i32_i64','arch_i32','arch_arm_i64','arch_ios'), array('Intel','Intel','Intel','Universal','Silicon'), $item->runtime_environment); ?></td>
           <td><?php echo $item->path; ?></td>
           <td><?php echo $item->info; ?></td>
         </tr>


### PR DESCRIPTION
Added architecture display and fixed the code for macos versions that return the architecture in arch_kind and not in runtime_environment

The version I have which came with the latest MR zip install seems slightly different to the one on github and I am not sure which version is the latest.